### PR TITLE
Fix "type qualifiers ignored on function return type" warning

### DIFF
--- a/riegeli/base/buffer.h
+++ b/riegeli/base/buffer.h
@@ -49,7 +49,7 @@ class Buffer {
 
   // Returns the data size, or the planned size if not allocated yet. The size
   // can increase when GetData() is called.
-  const size_t size() const { return size_; }
+  size_t size() const { return size_; }
 
   // Returns true if the buffer is already allocated and GetData() is fast.
   // Returns false if GetData() would allocate the buffer.


### PR DESCRIPTION
Compiling Riegeli in our project setup creates the following GCC warning/error:
`riegeli/base/buffer.h:52:3: type qualifiers ignored on function return type [-Werror=ignored-qualifiers]`

The reason is that the first `const` in the line has no effect, since it returns by value:
`const size_t size() const { return size_; }`