### PR TITLE
chore(bazel): add MODULE.bazel files for bzlmod

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,65 @@
+module(
+    name = "riegeli",
+    repo_name = "com_google_riegeli",
+)
+
+bazel_dep(
+    name = "abseil-cpp",
+    version = "20220623.1",
+    repo_name = "com_google_absl",
+)
+bazel_dep(
+    name = "boringssl",
+    version = "0.0.0-20240530-2db0eb3",
+)
+bazel_dep(
+    name = "brotli",
+    version = "1.1.0",
+    repo_name = "org_brotli",
+)
+bazel_dep(
+    name = "bzip2",
+    version = "1.0.8",
+)
+bazel_dep(
+    name = "crc32c",
+    version = "1.1.0",
+)
+bazel_dep(
+    name = "highwayhash",
+    version = "0.0.0-20240305-5ad3bf8",
+)
+bazel_dep(
+    name = "lz4",
+    version = "1.9.4",
+)
+bazel_dep(
+    name = "platforms",
+    version = "0.0.9",
+)
+bazel_dep(
+    name = "protobuf",
+    version = "3.19.0",
+    repo_name = "com_google_protobuf",
+)
+bazel_dep(
+    name = "rules_proto",
+    version = "4.0.0",
+)
+bazel_dep(
+    name = "snappy",
+    version = "1.2.0",
+)
+bazel_dep(
+    name = "xz",
+    version = "5.4.5.bcr.1",
+)
+bazel_dep(
+    name = "zlib",
+    version = "1.2.11",
+)
+bazel_dep(
+    name = "zstd",
+    version = "1.5.6",
+    repo_name = "net_zstd",
+)


### PR DESCRIPTION
This follows #28

There is no workflow to validate online ?

Have you considered using github action or even [buildkite](https://buildkite.com/)?

This is partial as I'm waiting for https://github.com/bazelbuild/bazel-central-registry/pull/1833 to be merged to add boringssl

I have modify certain BUILD file so the target are aligned with the one used in there repsective Module